### PR TITLE
feat: add search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ dist
 /**/build
 .vscode
 services
-src/__GENERATED_TYPES__

--- a/package-lock.json
+++ b/package-lock.json
@@ -4638,8 +4638,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -4660,14 +4659,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -4682,20 +4679,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -4812,8 +4806,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -4825,7 +4818,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -4840,7 +4832,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -4848,14 +4839,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -4874,7 +4863,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -4955,8 +4943,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -4968,7 +4955,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -5054,8 +5040,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -5091,7 +5076,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5111,7 +5095,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -5155,14 +5138,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -8750,21 +8731,6 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0",
         "value-equal": "^0.4.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
-          "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
-        }
       }
     },
     "hmac-drbg": {
@@ -10253,8 +10219,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10275,14 +10240,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10297,20 +10260,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -10427,8 +10387,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -10440,7 +10399,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -10455,7 +10413,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -10463,14 +10420,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -10489,7 +10444,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -10570,8 +10524,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -10583,7 +10536,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -10669,8 +10621,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -10706,7 +10657,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10726,7 +10676,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -10770,14 +10719,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -17888,7 +17835,7 @@
         "string-to-stream": "^1.1.0",
         "typescript": "~2.8.3",
         "typescript-json-schema": "github:quicktype/typescript-json-schema#d16083d29c8b6702c666a981fa6b21113300c059",
-        "unicode-properties": "github:quicktype/unicode-properties#dist",
+        "unicode-properties": "github:quicktype/unicode-properties#d5fddfea1ef9d05c6479a979e225476063e13f52",
         "universal-analytics": "^0.4.16",
         "urijs": "^1.19.1",
         "uuid": "^3.2.1"
@@ -20848,9 +20795,9 @@
       "dev": true
     },
     "tiny-invariant": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
-      "integrity": "sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
     },
     "tiny-warning": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,9 @@
     "url": "https://github.com/etclabscore/jade-explorer.git"
   },
   "scripts": {
-    "build": "npm run typings && react-scripts build",
-    "start": "npm run typings && react-scripts start",
-    "test": "npm run typings && react-scripts test",
-    "typings": "open-rpc-typings --output-ts src/__GENERATED_TYPES__ -d ./node_modules/@etclabscore/ethereum-json-rpc-specification/openrpc.json",
+    "build": "react-scripts build",
+    "start": "react-scripts start",
+    "test": "react-scripts test",
     "service-runner": "jade-service-runner",
     "lint": "tslint -p tsconfig.json"
   },
@@ -36,6 +35,7 @@
     "bignumber.js": "^4.1.0",
     "ethereumjs-util": "^6.1.0",
     "ethjs-unit": "^0.1.6",
+    "history": "^4.9.0",
     "moment": "^2.24.0",
     "qs": "^6.5.2",
     "raf": "^3.4.0",
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@etclabscore/jade-service-runner": "^1.2.3",
-    "@open-rpc/typings": "^1.4.3",
     "@types/bignumber.js": "^4.0.3",
     "@types/jest": "^21.1.6",
     "@types/node": "^8.0.51",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import { AppBar, CssBaseline, Theme, Toolbar, Typography, IconButton, Grid } from "@material-ui/core"; //tslint:disable-line
+import { AppBar, CssBaseline, Theme, Toolbar, Typography, IconButton, Grid, InputBase, Tooltip } from "@material-ui/core"; //tslint:disable-line
 import { makeStyles, ThemeProvider } from "@material-ui/styles";
 import Link from "@material-ui/core/Link";
 import { Link as RouterLink } from "react-router-dom";
-import React, { Dispatch } from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import React, { Dispatch, ChangeEvent, KeyboardEvent, useState } from "react";
+import { Router, Route, Switch } from "react-router-dom";
 import useDarkMode from "use-dark-mode";
 import "./App.css";
 import Address from "./containers/Address";
@@ -14,21 +14,27 @@ import Transaction from "./containers/Transaction";
 import ConfigurationMenu from "./containers/ConfigurationMenu";
 import { darkTheme, lightTheme } from "./themes/jadeTheme";
 import Brightness3Icon from "@material-ui/icons/Brightness3";
+import NotesIcon from "@material-ui/icons/Notes";
 import WbSunnyIcon from "@material-ui/icons/WbSunny";
+import CodeIcon from "@material-ui/icons/Code";
 
 import useInterval from "use-interval";
 import useServiceRunnerStore from "./stores/useServiceRunnerStore";
 import useMultiGethStore from "./stores/useMultiGethStore";
 import EthereumJSONRPC from "@etclabscore/ethereum-json-rpc";
+import ETHJSONSpec from "@etclabscore/ethereum-json-rpc-specification/openrpc.json";
+
+import createHistory from "history/createBrowserHistory";
+const history = createHistory();
 
 const useStyles = makeStyles((theme: Theme) => ({
   title: {
-    flexGrow: 1,
   },
 }));
 
 function App(props: any) {
   const darkMode = useDarkMode();
+  const [search, setSearch] = useState();
   const theme = darkMode.value ? darkTheme : lightTheme;
 
   const [, , setServiceRunnerUrl] = useServiceRunnerStore();
@@ -56,14 +62,63 @@ function App(props: any) {
     }
   }, 100, true);
 
+  const isAddress = (query: string): boolean => {
+    const re = new RegExp(ETHJSONSpec.components.schemas.Address.pattern);
+    return re.test(query);
+  };
+
+  const isKeccakHash = (query: string): boolean => {
+    const re = new RegExp(ETHJSONSpec.components.schemas.Keccak.pattern);
+    return re.test(query);
+  };
+
+  const isBlockNumber = (query: string): boolean => {
+    const re = new RegExp(/^-{0,1}\d+$/);
+    return re.test(query);
+  };
+
+  const handleSearch = async (query: string) => {
+    if (isAddress(query)) {
+      history.push(`/address/${query}`);
+    }
+    if (isKeccakHash(query)) {
+      let transaction;
+
+      try {
+        transaction = await erpc.eth_getTransactionByHash(query);
+      } catch (e) {
+        // do nothing
+      }
+
+      if (transaction) {
+        history.push(`/tx/${query}`);
+      }
+      let block;
+      try {
+        block = await erpc.eth_getBlockByHash(query, false);
+      } catch (e) {
+        // do nothing
+      }
+      if (block) {
+        history.push(`/block/${query}`);
+      }
+    }
+    if (isBlockNumber(query)) {
+      const block = await erpc.eth_getBlockByNumber(`0x${parseInt(query, 10).toString(16)}`, false);
+      if (block) {
+        history.push(`/block/${block.hash}`);
+      }
+    }
+  };
+
   return (
-    <Router >
+    <Router history={history}>
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <AppBar color="default" elevation={0}>
+        <AppBar position="static" color="default" elevation={0}>
           <Toolbar>
-            <Grid justify="space-between" container>
-              <Grid item style={{marginTop: "8px"}}>
+            <Grid justify="space-between" alignItems="center" alignContent="center" container>
+              <Grid item style={{ marginTop: "8px" }} direction="row">
                 <Link
                   component={({ className, children }: { children: any, className: string }) => (
                     <RouterLink className={className} to={"/"}>
@@ -71,33 +126,73 @@ function App(props: any) {
                     </RouterLink>
                   )}>
                   <Grid container>
-                    {darkMode.value ?
-                      <img
-                        alt="jade-explorer"
-                        height="30"
-                        style={{ marginRight: "5px" }}
-                        src="https://github.com/etclabscore/jade-media-assets/blob/master/jade-logo-dark/jade-logo-dark%20(PNG)/32x32.png?raw=true" //tslint:disable-line
-                      />
-                      :
-                      <img
-                        alt="jade-explorer"
-                        height="30"
-                        style={{ marginRight: "5px" }}
-                        src="https://github.com/etclabscore/jade-media-assets/blob/master/jade-logo-light/jade-logo-light%20(PNG)/32x32.png?raw=true" //tslint:disable-line
-                      />
-                    }
-                    <Typography className={classes.title} color="textSecondary" variant="h6">Jade Explorer</Typography>
+                    <Grid>
+                      {darkMode.value ?
+                        <img
+                          alt="jade-explorer"
+                          height="30"
+                          style={{ marginRight: "5px" }}
+                          src="https://github.com/etclabscore/jade-media-assets/blob/master/jade-logo-dark/jade-logo-dark%20(PNG)/32x32.png?raw=true" //tslint:disable-line
+                        />
+                        :
+                        <img
+                          alt="jade-explorer"
+                          height="30"
+                          style={{ marginRight: "5px" }}
+                          src="https://github.com/etclabscore/jade-media-assets/blob/master/jade-logo-light/jade-logo-light%20(PNG)/32x32.png?raw=true" //tslint:disable-line
+                        />
+                      }
+                    </Grid>
+                    <Grid>
+                      <Typography className={classes.title} color="textSecondary" variant="h6">Jade Explorer</Typography>
+                    </Grid>
                   </Grid>
                 </Link>
               </Grid>
+              <Grid item xs={7}>
+                <InputBase
+                  placeholder="Enter an Address, Transaction Hash or Block Number"
+                  onKeyDown={
+                    (event: KeyboardEvent<HTMLInputElement>) => {
+                      if (event.keyCode === 13) {
+                        handleSearch(search.trim());
+                      }
+                    }
+                  }
+                  onChange={
+                    (event: ChangeEvent<HTMLInputElement>) => {
+                      setSearch(event.target.value);
+                    }
+                  }
+                  fullWidth
+                  style={{ background: "rgba(0,0,0,0.1)", borderRadius: "4px", padding: "0px 10px", marginRight: "5px" }}
+                />
+              </Grid>
               <Grid item>
-                <IconButton onClick={darkMode.toggle}>
-                  {darkMode.value ? <Brightness3Icon /> : <WbSunnyIcon />}
-                </IconButton>
+                <Tooltip title="JSOSN-RPC API Documentation">
+                  <IconButton
+                    onClick={() =>
+                      window.open("https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/etclabscore/ethereum-json-rpc-specification/master/openrpc.json")
+                    }>
+                    <NotesIcon />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Jade Explorer Github">
+                  <IconButton
+                    onClick={() =>
+                      window.open("https://github.com/etclabscore/jade-explorer")
+                    }>
+                    <CodeIcon />
+                  </IconButton>
+                </Tooltip>
                 <ConfigurationMenu onChange={handleConfigurationChange} />
+                <Tooltip title="Toggle Dark Mode">
+                  <IconButton onClick={darkMode.toggle}>
+                    {darkMode.value ? <Brightness3Icon /> : <WbSunnyIcon />}
+                  </IconButton>
+                </Tooltip>
               </Grid>
             </Grid>
-
           </Toolbar>
         </AppBar>
         <div style={{ margin: "0px 25px 0px 25px" }}>

--- a/src/components/BlockCard/BlockCard.tsx
+++ b/src/components/BlockCard/BlockCard.tsx
@@ -5,7 +5,7 @@ import { Card, CardHeader, CardContent, Typography, Chip } from "@material-ui/co
 import hexToDate from "../../helpers/hexToDate";
 import hexToString from "../../helpers/hexToString";
 import hexToNumber from "../../helpers/hexToNumber";
-import { GetBlockByNumberResult as IBlock } from "../../__GENERATED_TYPES__";
+import { GetBlockByNumberResult as IBlock } from "@etclabscore/ethereum-json-rpc";
 
 interface IProps {
   block: IBlock;

--- a/src/containers/ConfigurationMenu/ConfigurationMenu.tsx
+++ b/src/containers/ConfigurationMenu/ConfigurationMenu.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { IconButton, Menu, MenuItem, ListItemText, ListItemSecondaryAction, Input, ListItemIcon } from "@material-ui/core"; //tslint:disable-line
-import { Settings, NavigateNext, NavigateBefore } from "@material-ui/icons";
+import { IconButton, Menu, MenuItem, ListItemText, ListItemSecondaryAction, Input, ListItemIcon, Tooltip } from "@material-ui/core"; //tslint:disable-line
+import { NavigateNext, NavigateBefore } from "@material-ui/icons";
+import SettingsIcon from "@material-ui/icons/Settings";
 
 interface IConfigurationMenuProps {
   onChange: (type: string, url: string) => any;
@@ -74,15 +75,17 @@ const ConfigurationMenu: React.FC<IConfigurationMenuProps> = (props) => {
 
   return (
     <>
-      <IconButton
-        aria-label="Account of current user"
-        aria-controls="menu-appbar"
-        aria-haspopup="true"
-        onClick={handleMenu}
-        color="inherit"
-      >
-        <Settings />
-      </IconButton>
+      <Tooltip title="Configuration">
+        <IconButton
+          aria-label="Configuration"
+          aria-controls="menu-appbar"
+          aria-haspopup="true"
+          onClick={handleMenu}
+          color="inherit"
+        >
+          <SettingsIcon color="action"/>
+        </IconButton>
+      </Tooltip>
       <Menu
         id="menu-appbar"
         getContentAnchorEl={null}


### PR DESCRIPTION
This adds the search bar to be able to search by transaction hash, block hash, block number, or address.
It also adds links to the explorers github page and to the static Ethereum JSON-RPC API Documentation

fixes #28
fixes #60


![explorer_search_icons](https://user-images.githubusercontent.com/364566/64719880-0bc5f000-d47e-11e9-8cd4-65f15632e074.gif)




![explorer_search](https://user-images.githubusercontent.com/364566/64719891-0f597700-d47e-11e9-9acb-4ee5e6ade869.gif)
