### PR TITLE
fix: custom eth rpc url

### DIFF
--- a/src/hooks/useMultiGeth.ts
+++ b/src/hooks/useMultiGeth.ts
@@ -12,13 +12,13 @@ function useMultiGeth(
   queryUrlOverride?: string,
 ): [ERPC | undefined, Dispatch<string>] {
   const [erpc, setErpc] = React.useState<undefined | ERPC>();
-  const [urlOverride, setUrlOverride] = useState(process.env.REACT_APP_ETH_RPC_URL);
+  const [urlOverride, setUrlOverride] = useState(queryUrlOverride || process.env.REACT_APP_ETH_RPC_URL);
   React.useEffect(() => {
-    if (!serviceRunner) {
-      return;
-    }
     const runAsync = async () => {
-      if (!queryUrlOverride) {
+      if (!urlOverride) {
+        if (!serviceRunner) {
+          return;
+        }
         const installed = await serviceRunner.installService(serviceName, version);
         if (!installed) {
           return;
@@ -27,7 +27,7 @@ function useMultiGeth(
       }
       let parsedUrl;
       try {
-        parsedUrl = new URL(queryUrlOverride || urlOverride || `${serviceRunnerUrl}/${serviceName}/${env}/${version}`);
+        parsedUrl = new URL(urlOverride || `${serviceRunnerUrl}/${serviceName}/${env}/${version}`);
       } catch (e) {
         return;
       }
@@ -57,8 +57,8 @@ function useMultiGeth(
         erpc.rpc.requestManager.close();
       }
     };
- // eslint-disable-next-line react-hooks/exhaustive-deps
- }, [serviceRunner, serviceRunnerUrl, version, env, urlOverride, queryUrlOverride]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serviceRunner, serviceRunnerUrl, version, env, urlOverride, queryUrlOverride]);
   return [erpc, setUrlOverride];
 }
 

--- a/src/hooks/useServiceRunner.ts
+++ b/src/hooks/useServiceRunner.ts
@@ -1,11 +1,16 @@
 import JadeServiceRunner, { ObjectT84Ta8SE as IAvailableServices } from "@etclabscore/jade-service-runner-client";
 import React, { Dispatch, useEffect } from "react";
+import { useQueryParam, StringParam } from "use-query-params";
 
 function useServiceRunner(defaultUrl: string): [JadeServiceRunner | undefined, string, Dispatch<string>, IAvailableServices[]] { //tslint:disable-line
   const [url, setUrl] = React.useState(defaultUrl);
   const [serviceRunner, setServiceRunner] = React.useState<JadeServiceRunner | undefined>();
   const [availableServices, setAvailableServices] = React.useState<IAvailableServices[]>([]);
+  const [rpcUrlQuery] = useQueryParam("rpcUrl", StringParam);
   React.useEffect(() => {
+    if (process.env.REACT_APP_ETH_RPC_URL || rpcUrlQuery) {
+      return;
+    }
     if (!url) {
       return;
     }


### PR DESCRIPTION
- combined env override and queryUrl override to simplify useMultiGeth hook
- return early from service runner hook if custom settings are present

fixes #156